### PR TITLE
Base class conditional iterator

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 2.8)
 project(injection)
 include_directories(../ panku)
 
-set(CMAKE_CXX_FLAGS "-Wall -Werror -Wextra -std=c++14")
+set(CMAKE_CXX_FLAGS "-Wall -Werror -Wextra -std=c++14 -g")
 add_executable(main main.cpp Devices.cpp ExampleDeviceClasses.cpp)

--- a/example/ExampleDeviceClasses.h
+++ b/example/ExampleDeviceClasses.h
@@ -1,12 +1,17 @@
 #pragma once
 
-class Alpha {
+class AlphaBetaParent {
+public:
+   virtual void Talk() = 0;
+};
+
+class Alpha: public AlphaBetaParent {
 public:
    void Talk();
    Alpha();
 };
 
-class Beta {
+class Beta: public AlphaBetaParent {
 public:
    Beta(Alpha& alpha);
    void Talk();

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,4 +1,5 @@
 #include "Devices.h"
+#include <iostream>
 
 panku devices;
 
@@ -10,4 +11,10 @@ int main(void) {
    devices.Get<Alpha>().Talk();
    devices.Get<Beta>().Talk();
    devices.Get<Gamma>().Talk();
+
+   std::cout << "Now we will test iteration by parent class, for Alpha and Beta" << std::endl;
+   // It is possible to iterate by base or derived class as well.
+   devices.ForEach<AlphaBetaParent>([](AlphaBetaParent& parent) {
+      parent.Talk();   
+   });
 }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -15,6 +15,6 @@ int main(void) {
    std::cout << "Now we will test iteration by parent class, for Alpha and Beta" << std::endl;
    // It is possible to iterate by base or derived class as well.
    devices.ForEach<AlphaBetaParent>([](AlphaBetaParent& parent) {
-      parent.Talk();   
+      parent.Talk();
    });
 }

--- a/private/Metaprogram.h
+++ b/private/Metaprogram.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <tuple>
+#include <type_traits>
+#include <iostream>
+#include <functional>
 
 #include "TypeList.h"
 #include "TupleManipulation.h"
@@ -40,6 +43,14 @@
             for(;;); \
          return *userObjectPointer; \
       } \
+      template<typename UserClass> \
+      void ForEach(std::function<void(UserClass&)> f) \
+      { \
+         TupleManipulation::for_each_in_tuple(userClassTuple, [f](auto element) {  \
+               std::cout << typeid(UserClass).name() << " / " << typeid(decltype(*element)).name() << std::endl;\
+               PankuMetaprogram::ConditionalFunctor<decltype(*element), UserClass, decltype(f)> (*element, f);\
+            }); \
+      } \
    private: \
       PankuClassTuple userClassTuple; \
       bool mInitialised; \
@@ -53,6 +64,22 @@ UserClass& ConstructAndInitialise();
 
 namespace PankuMetaprogram
 {
+
+   // Applies the functor if Child is derived from Parent
+   // The base case (where Child is NOT derived) doess nothing
+   template<class Child, class Parent, typename Functor>
+   inline typename std::enable_if<!std::is_base_of<Parent, Child>::value, void>::type
+   ConditionalFunctor(Child&, Functor) 
+   {
+   }
+
+   template<class Child, class Parent, typename Functor>
+   inline typename std::enable_if<std::is_base_of<Parent, Child>::value, void>::type
+   ConditionalFunctor(Child& childObject, Functor functor) 
+   {
+      functor(*childObject);
+   }
+
    // Turns a type list into a type list of its pointer types.
    template<class List>
    struct type_list_pointerise;

--- a/private/Metaprogram.h
+++ b/private/Metaprogram.h
@@ -2,7 +2,6 @@
 
 #include <tuple>
 #include <type_traits>
-#include <iostream>
 #include <functional>
 
 #include "TypeList.h"
@@ -47,8 +46,7 @@
       void ForEach(std::function<void(UserClass&)> f) \
       { \
          TupleManipulation::for_each_in_tuple(userClassTuple, [f](auto element) {  \
-               std::cout << typeid(UserClass).name() << " / " << typeid(decltype(*element)).name() << std::endl;\
-               PankuMetaprogram::ConditionalFunctor<decltype(*element), UserClass, decltype(f)> (*element, f);\
+               PankuMetaprogram::ConditionalFunctor<typename std::remove_pointer<decltype(element)>::type, UserClass, decltype(f)> (*element, f); \
             }); \
       } \
    private: \
@@ -66,18 +64,17 @@ namespace PankuMetaprogram
 {
 
    // Applies the functor if Child is derived from Parent
-   // The base case (where Child is NOT derived) doess nothing
+   // The base case (where Child is NOT derived) does nothing
    template<class Child, class Parent, typename Functor>
    inline typename std::enable_if<!std::is_base_of<Parent, Child>::value, void>::type
-   ConditionalFunctor(Child&, Functor) 
-   {
-   }
+   ConditionalFunctor(Child&, Functor)
+   {}
 
    template<class Child, class Parent, typename Functor>
    inline typename std::enable_if<std::is_base_of<Parent, Child>::value, void>::type
-   ConditionalFunctor(Child& childObject, Functor functor) 
+   ConditionalFunctor(Child& childObject, Functor functor)
    {
-      functor(*childObject);
+      functor(childObject);
    }
 
    // Turns a type list into a type list of its pointer types.


### PR DESCRIPTION
Adds a templated ForEach function to Panku, that allows to apply a functor to all classes that are derived from the same parent.

This same format could be used to iterate and apply functors based on any other type_traits criteria (potentially passing the criterion as a strategy).